### PR TITLE
방송이 켜지면 자동 새로고침 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 ~npm run build 시 tailwindcss.js dist 폴더에 복사~
+
 menifest.json 에서 web_accessible_resources 요소 변경하여 자동복사

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-npm run build 시 tailwindcss.js dist 폴더에 복사
+~npm run build 시 tailwindcss.js dist 폴더에 복사~
+menifest.json 에서 web_accessible_resources 요소 변경하여 자동복사

--- a/main.html
+++ b/main.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>잉친쓰 DLC Rev.beta</title>
     <script src="./tailwindcss.js"></script>
-    <style>
+    <!-- <style>
         body::-webkit-scrollbar {
             width: 10px;
         }
@@ -18,7 +18,7 @@
             background-color: #999;
             border-radius: 10px;
         }
-    </style>
+    </style> -->
 </head>
 <body style="min-width:790px;" class="text-slate-900 bg-slate-50 px-2 py-4">
     <header>

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,8 @@
         "js": [
           "src/mujisung.js",
           "src/controller.js",
-          "src/twitchBtns.js"
+          "src/twitchBtns.js",
+          "src/broadCheck.js"
         ]
       },
       {

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
       {
         "resources": [
           "src/config.mjs",
-          "src/utils.mjs"
+          "src/utils.mjs",
+          "tailwindcss.js"
         ],
         "type": "module",
         "matches": [

--- a/src/broadCheck.js
+++ b/src/broadCheck.js
@@ -1,0 +1,54 @@
+var checkIntervalFlag = false;
+
+setTimeout(() => {
+    const currentUrl = window.location.href;
+    const urlElements = currentUrl.split("/");
+    const broadId = urlElements.pop();
+    const userId = urlElements.pop();
+    if(broadId == "null"){
+        checkLoop(userId);
+    }
+
+    const boradOffTarget = document.getElementById('layerAirOff');
+    const observer = new MutationObserver(mutations => {
+        mutations.forEach(function(mutation) {
+            // 스타일 속성의 변경을 확인
+            if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                // 스타일 속성이 변경된 요소
+                var targetElement = mutation.target;
+                // 변경된 스타일 속성 가져오기
+                var newStyle = targetElement.style.cssText;
+                // 방종을 하면 layerAirOff 요소에 "display: block" 이 추가됩니다.
+                if (newStyle.includes('display: block')) {
+                    checkLoop(userId);
+                }
+            }
+        });
+    })
+    // 감시할 대상 요소 및 구성 옵션
+    const config = { attributes: true, attributeFilter: ['style'], subtree: false };
+    // 감시 시작
+    observer.observe(boradOffTarget, config);
+},500)
+
+function checkLoop(userId) {
+    // observer에서 중복체크가 발생해서 interval 을 한번만 실행시키기위해 플래그 체크를 합니다.
+    if(checkIntervalFlag) return
+    checkIntervalFlag = true;
+    console.log('방송이 시작되면 새로고침 합니다.');
+    const xhr = new XMLHttpRequest();
+    xhr.responseType = 'json'
+    const interval = setInterval(function(){
+        xhr.open("GET", `https://bjapi.afreecatv.com/api/${userId}/station`)
+        xhr.send();
+    },3000);
+    
+    xhr.onreadystatechange = (e)=>{
+        if(xhr.response === null || xhr.response.broad === null) {
+            return
+        }
+        checkIntervalFlag = false;
+        clearInterval(interval)
+        window.location.href = `https://play.afreecatv.com/${userId}/${xhr.response.broad}`;
+    }
+}


### PR DESCRIPTION
방송이 꺼져있는 경우에 해당 방송국의 방송이 시작되면 자동으로 새로고침 하는 기능을 추가해봤습니다.
아래 두 문제가 있는데, 확인해보시고 문제없으면 PR 받아주시면 감사하겠습니다.

1. main.html : 7 번째줄에 있는 부분이 npm run build 하면 에러로 빠져서 주석처리해놓고 작업했습니다. 
저도 vite는 안써봐서 무슨 에러인지 잘모르는데 일단 주석처리해뒀습니다. 나중에 dist 부분에서만 주석 빼주면 될 것 같습니다.
2. 방송이 꺼져있는상태로 페이지 들어가면 정상작동하는데, 방종을 감지하는 부분에서 observer가 미쳐날뛰어서 체킹이 여러번됩니다. 
때문에 inverval에 플래그를 넣어서 한번만 작동하게 해두었는데, 방종 감지를 다른방식으로 해야할 것 같으나 시간이 없어 이렇게 두었습니다. 큰 문제는 없을것같긴한데, 일단 말씀드립니다.